### PR TITLE
Installer now takes command line arguments and can run in non-interactive mode.

### DIFF
--- a/jolie_installer/src/jolie/installer/Installer.java
+++ b/jolie_installer/src/jolie/installer/Installer.java
@@ -223,12 +223,13 @@ public class Installer {
 				}
 			}
 		});
-		
+
 		process.waitFor();
 		e1.shutdown();
 		e2.shutdown();
 		e3.shutdown();
 		process.destroy();
+
 	} catch (IOException err) {
 //		err.printStackTrace();
 		}
@@ -320,7 +321,7 @@ public class Installer {
 		char fs = File.separatorChar;
 		
 		runJolie( tmp.getParent(), jolieDir, args );
-		
+
 //		URL[] urls = new URL[] { new URL( "file:" + jolieDir + fs + "jolie.jar" ), new URL( "file:" + jolieDir + fs + "lib" + fs + "libjolie.jar" ) };
 //		ClassLoader cl = new URLClassLoader( urls, Installer.class.getClassLoader() );
 //		Class<?> jolieClass = cl.loadClass( "jolie.Jolie" );

--- a/jolie_installer/src/jolie/installer/Installer.java
+++ b/jolie_installer/src/jolie/installer/Installer.java
@@ -34,6 +34,7 @@ import java.io.OutputStream;
 import java.io.OutputStreamWriter;
 import java.lang.reflect.InvocationTargetException;
 import java.nio.channels.Channels;
+import java.util.Arrays;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.zip.ZipEntry;
@@ -272,13 +273,13 @@ public class Installer {
 	 * @param args program arguments
 	 * @return whitespace separated argument string or a empty string if no arguments
      */
-	private String argumentBuilder(String[] args) {
-		if (args != null && args.length > 0) {
+	private String argumentBuilder( String[] args ) {
+		if ( args != null && args.length > 0 ) {
 			StringBuilder argsList = new StringBuilder();
-			for (int i = 0; i < args.length; ++i) {
-				argsList.append(args[0]);
-				if (i < args.length - 1) { // we don't like spaces at the end
-					argsList.append(" ");
+			for ( int i = 0; i < args.length; ++i ) {
+				argsList.append( args[i] );
+				if ( i < args.length - 1 ) { // we don't like spaces at the end
+					argsList.append( " " );
 				}
 			}
 			return argsList.toString();
@@ -300,7 +301,7 @@ public class Installer {
 		try {
 			String arguments, cmd;
 			cmd = getLauncher( os, jolieDir ); // get the corresponding jolie launcher script
-			arguments = argumentBuilder(args); // build argument string
+			arguments = argumentBuilder( args ); // build argument string
 
 			cmd += " " + wdir + File.separator + "installer.ol " + os + " " + arguments;
 
@@ -319,7 +320,7 @@ public class Installer {
 		File tmp = createTmpDist();
 		String jolieDir = new File( tmp, "jolie" ).getAbsolutePath();
 		char fs = File.separatorChar;
-		
+
 		runJolie( tmp.getParent(), jolieDir, args );
 
 //		URL[] urls = new URL[] { new URL( "file:" + jolieDir + fs + "jolie.jar" ), new URL( "file:" + jolieDir + fs + "lib" + fs + "libjolie.jar" ) };

--- a/jolie_installer/src/jolie/installer/Installer.java
+++ b/jolie_installer/src/jolie/installer/Installer.java
@@ -265,8 +265,27 @@ public class Installer {
 			throw new Exception("IOException");
 	}
 }
+
+	/**
+	 * Produces a whitespace separated argument string for parsing to the installer script
+	 * @param args program arguments
+	 * @return whitespace separated argument string or a empty string if no arguments
+     */
+	private String argumentBuilder(String[] args) {
+		if (args != null && args.length > 0) {
+			StringBuilder argsList = new StringBuilder();
+			for (int i = 0; i < args.length; ++i) {
+				argsList.append(args[0]);
+				if (i < args.length - 1) { // we don't like spaces at the end
+					argsList.append(" ");
+				}
+			}
+			return argsList.toString();
+		}
+		return "";
+	}
 	
-	private void runJolie( String wdir, String jolieDir ){
+	private void runJolie( String wdir, String jolieDir, String[] args ){
 //		String ext = "";
 //		String replaceVar;
 		
@@ -278,9 +297,12 @@ public class Installer {
 //		}
 		
 		try {
-			// get the corresponding jolie launcher script
-			String cmd = getLauncher( os, jolieDir );
-			cmd += " " + wdir + File.separator + "installer.ol " + os;
+			String arguments, cmd;
+			cmd = getLauncher( os, jolieDir ); // get the corresponding jolie launcher script
+			arguments = argumentBuilder(args); // build argument string
+
+			cmd += " " + wdir + File.separator + "installer.ol " + os + " " + arguments;
+
 			runCmd( cmd );
 			
 		} catch (InterruptedException ex) {
@@ -288,7 +310,7 @@ public class Installer {
 		}
 	}
 		
-	public void run()
+	public void run(String[] args)
 		throws IOException, InterruptedException,
 		ClassNotFoundException, NoSuchMethodException,
 		IllegalAccessException, InvocationTargetException, Exception
@@ -297,7 +319,7 @@ public class Installer {
 		String jolieDir = new File( tmp, "jolie" ).getAbsolutePath();
 		char fs = File.separatorChar;
 		
-		runJolie( tmp.getParent(), jolieDir );
+		runJolie( tmp.getParent(), jolieDir, args );
 		
 //		URL[] urls = new URL[] { new URL( "file:" + jolieDir + fs + "jolie.jar" ), new URL( "file:" + jolieDir + fs + "lib" + fs + "libjolie.jar" ) };
 //		ClassLoader cl = new URLClassLoader( urls, Installer.class.getClassLoader() );

--- a/jolie_installer/src/jolie/installer/JolieInstaller.java
+++ b/jolie_installer/src/jolie/installer/JolieInstaller.java
@@ -31,6 +31,7 @@ public class JolieInstaller
 	{
 		try {
 			new Installer().run(args);
+			System.exit(0); // installer keeps hanging around after the sub process has been stopped?
 		} catch( Exception e ) {
 			e.printStackTrace();
 		}

--- a/jolie_installer/src/jolie/installer/JolieInstaller.java
+++ b/jolie_installer/src/jolie/installer/JolieInstaller.java
@@ -30,7 +30,7 @@ public class JolieInstaller
 	public static void main( String[] args ) throws Exception
 	{
 		try {
-			new Installer().run();
+			new Installer().run(args);
 		} catch( Exception e ) {
 			e.printStackTrace();
 		}

--- a/scripts/installer.ol
+++ b/scripts/installer.ol
@@ -87,8 +87,7 @@ define getArguments
 		} else if ( args[i] == "-h" || args[i] == "--help" || args[i] == "/h" || args[i] == "/help" ) {
 			showHelp = true	
 		} else {
-			// Argument not understood
-			interactive = false
+			showHelp = true
 		}
 	}
 }
@@ -158,9 +157,7 @@ main
 				}	
 			} else {
 				// non-stop, non-interactive install mode
-				print@Console(
-					"\nDirectory " + jh + " already exists.\n\n"
-				)()
+				print@Console( "\nDirectory " + jh + " already exists.\n\n" )()
 			}
 		} else {
 			println@Console( "\nDirectory " + jh + " does not exist. It has now been created." )();
@@ -196,9 +193,9 @@ main
 		installationFinished@OSInst( jh )();
 
 		if ( interactive ) {
-			println@Console("\nJolie is installed. Try running 'jolie' under a new shell")()
+			println@Console( "\nJolie is installed. Try running 'jolie' under a new shell" )()
 		} else {
-			println@Console("\nJolie is installed.")()
+			println@Console( "\nJolie is installed." )()
 		}
 	}
 }

--- a/scripts/installer.ol
+++ b/scripts/installer.ol
@@ -36,7 +36,7 @@ Interfaces: InstInterface
 define setJHProc
 {
 	getDJH@OSInst()( djh );
-	if ( !nonStop ) {
+	if ( interactive ) {
 		print@Console(
 		"\nInsert the path for the environment variable " + JOLIE_HOME + ".\n"
 		+ JOLIE_HOME + " indicates the directory in which the Jolie"
@@ -57,7 +57,7 @@ define setJHProc
 define setLPProc
 {
 	getDLP@OSInst()( dlp );
-	if ( !nonStop ) {
+	if ( interactive ) {
 		print@Console(
 			"\nInsert the installation path for the Jolie launcher executables\n" +
 			"[press Enter to use the default value: " + dlp + "]\nPlease note that using spaces in paths may cause problems.\n\n > "
@@ -80,14 +80,15 @@ define setLPProc
  */ 
 define getArguments
 {
+	interactive = true;
 	for ( i = 1, i < #args, ++i ) {
 		if ( args[i] == "-y" || args[i] == "/y" ) {
-			nonStop = true
+			interactive = false
 		} else if ( args[i] == "-h" || args[i] == "--help" || args[i] == "/h" || args[i] == "/help" ) {
 			showHelp = true	
 		} else {
 			// Argument not understood
-			showHelp = true
+			interactive = false
 		}
 	}
 }
@@ -101,8 +102,29 @@ main
 	};
 	getArguments;
 
-	if (!showHelp) {
-		if ( nonStop ) {
+	if ( showHelp ) {
+		println@Console(
+			"Jolie installer\n\nUsage:\njava -jar <Jolie installer jar> [options...]\n\n" +
+			"Following options are available:"
+			)();
+		if (args[0] == "nix") {
+			println@Console( 
+				"    -h | --help\t Show this help message\n" +
+				"    -y\t Run the installer in non-interactive mode (Note: This does not set the environmental variable JOLIE_HOME, do this manually)\n" 
+			)()
+		} else {
+			// windows cmd
+			println@Console( 
+				"    /h | /help\t Show this help message\n" +
+				"    /y\t Run the installer in non-interactive mode\n" 
+			)()
+		};
+		println@Console(
+			"See http://http://jolie-lang.org/downloads.html for further details"
+			)()
+
+	} else {
+		if ( !interactive ) {
 			println@Console("Starting install in non-stop; non-interactive mode.\n")()	
 		};
 
@@ -117,7 +139,7 @@ main
 		
 		exists@File( jh )( exists );
 		if ( exists ) {
-			if ( !nonStop ) {
+			if ( interactive ) {
 				// interactive 'normal' install mode 
 				print@Console(
 				"\nThe target installation directory " + jh + " already exists.\n"
@@ -173,30 +195,10 @@ main
 
 		installationFinished@OSInst( jh )();
 
-		if ( nonStop ) {
-			println@Console("\nJolie is installed.")()
-		} else {
+		if ( interactive ) {
 			println@Console("\nJolie is installed. Try running 'jolie' under a new shell")()
-		}
-	} else {
-		println@Console(
-			"Jolie installer\n\nUsage:\njava -jar <Jolie installer jar> [options...]\n\n" +
-			"Following options are available:"
-			)();
-		if (args[0] == "nix") {
-			println@Console( 
-				"    -h | --help\t Show this help message\n" +
-				"    -y\t Run the installer in non-interactive mode (Note: This does not set the environmental variable JOLIE_HOME, do this manually)\n" 
-			)()
 		} else {
-			// windows cmd
-			println@Console( 
-				"    /h | /help\t Show this help message\n" +
-				"    /y\t Run the installer in non-interactive mode\n" 
-			)()
-		};
-		println@Console(
-			"See http://http://jolie-lang.org/downloads.html for further details"
-			)()
+			println@Console("\nJolie is installed.")()
+		}
 	}
 }

--- a/scripts/installer.ol
+++ b/scripts/installer.ol
@@ -36,15 +36,19 @@ Interfaces: InstInterface
 define setJHProc
 {
 	getDJH@OSInst()( djh );
-	print@Console(
+	if ( !nonStop ) {
+		print@Console(
 		"\nInsert the path for the environment variable " + JOLIE_HOME + ".\n"
 		+ JOLIE_HOME + " indicates the directory in which the Jolie"
 		+ " libraries will be installed."
 		+ "\n[press Enter to use the default value: " + djh + "]\nPlease note that using spaces in paths may cause problems.\n\n > "
-	)();
-	in( jh );
-	trim@StringUtils( jh )( jh );
-	if ( jh == "" ) {
+		)();
+		in( jh );
+		trim@StringUtils( jh )( jh );
+		if ( jh == "" ) {
+			jh = djh
+		}	
+	} else {
 		jh = djh
 	};
 	normalisePath@OSInst( jh )( jh )
@@ -53,16 +57,39 @@ define setJHProc
 define setLPProc
 {
 	getDLP@OSInst()( dlp );
-	print@Console(
-		"\nInsert the installation path for the Jolie launcher executables\n" +
-		"[press Enter to use the default value: " + dlp + "]\nPlease note that using spaces in paths may cause problems.\n\n > "
-	)();
-	in( lp );
-	trim@StringUtils( lp )( lp );
-	if ( lp == "" ) {
+	if ( !nonStop ) {
+		print@Console(
+			"\nInsert the installation path for the Jolie launcher executables\n" +
+			"[press Enter to use the default value: " + dlp + "]\nPlease note that using spaces in paths may cause problems.\n\n > "
+		)();
+		in( lp );
+		trim@StringUtils( lp )( lp );
+		if ( lp == "" ) {
+			lp = dlp
+		}
+	} else {
 		lp = dlp
 	};
 	normalisePath@OSInst( lp )( lp )
+}
+
+/* 
+ * Make command line flags setting possible in a abitrary way, after the first argument (reserved for OS choice).
+ * Certain flags (such as the help flag) may have a higher priority than others and thus override the actions of other flags. 
+ * When flags are not recognized the help message is shown, and the installation process is skipped. 
+ */ 
+define getArguments
+{
+	for ( i = 1, i < #args, ++i ) {
+		if ( args[i] == "-y" || args[i] == "/y" ) {
+			nonStop = true
+		} else if ( args[i] == "-h" || args[i] == "--help" || args[i] == "/h" || args[i] == "/help" ) {
+			showHelp = true	
+		} else {
+			// Argument not understood
+			showHelp = true
+		}
+	}
 }
 
 main
@@ -72,61 +99,104 @@ main
 	if( args[0] == "macos" || args[0] == "linux" ) {
 		args[0] = "nix"
 	};
-	eInfo.filepath = args[0] + "_installer.ol";
-	loadEmbeddedService@Runtime( eInfo )( OSInst.location );
+	getArguments;
 
-	// unzipDist@OSInst()();
-
-	registerForInput@Console()();
-	setJHProc;
-	exists@File( jh )( exists );
-	if ( exists ) {
-		print@Console(
-			"\nThe target installation directory " + jh + " already exists.\n"
-			+ "Delete it before proceeding? [y/N]\n\n > "
-		)();
-		in( decision );
-		while( decision != "y" && decision != "" && decision != "n" ) {
-			print@Console( "\nOption not understood, please choose y or n.\n\n >" )();
-			in( decision )
+	if (!showHelp) {
+		if ( nonStop ) {
+			println@Console("Starting install in non-stop; non-interactive mode.\n")()	
 		};
-		if ( decision == "y" ) {
-			println@Console( "\nDeleting directory " + jh )();
-			deleteDir@OSInst( jh )();
+
+		eInfo.filepath = args[0] + "_installer.ol";
+		loadEmbeddedService@Runtime( eInfo )( OSInst.location );
+
+		// unzipDist@OSInst()();
+
+		registerForInput@Console()();
+		setJHProc;
+		
+		
+		exists@File( jh )( exists );
+		if ( exists ) {
+			if ( !nonStop ) {
+				// interactive 'normal' install mode 
+				print@Console(
+				"\nThe target installation directory " + jh + " already exists.\n"
+				+ "Delete it before proceeding? [y/N]\n\n > "
+				)();
+				in( decision );
+				while( decision != "y" && decision != "" && decision != "n" ) {
+					print@Console( "\nOption not understood, please choose y or n.\n\n >" )();
+					in( decision )
+				};
+				if ( decision == "y" ) {
+					println@Console( "\nDeleting directory " + jh )();
+					deleteDir@OSInst( jh )();
+					println@Console( "\nDirectory " + jh + " does not exist. It has now been created." )();
+					mkdir@OSInst( jh )()
+				}	
+			} else {
+				// non-stop, non-interactive install mode
+				print@Console(
+					"\nDirectory " + jh + " already exists.\n\n"
+				)()
+			}
+		} else {
 			println@Console( "\nDirectory " + jh + " does not exist. It has now been created." )();
 			mkdir@OSInst( jh )()
+		};
+
+		
+		install ( CannotCopyBins => 
+			sleep@Time( 1000 )();
+			println@Console( main.CannotCopyBins.message )();
+			throw( FaultInstallation )
+		);
+		copyBins@OSInst( jh )();
+			
+		println@Console( "\nJolie libraries installed in path " + jh + "\n" )();
+
+		setLPProc;
+		isDirectory@File( lp )( exists );
+		if ( !exists ) {
+			println@Console( "\nDirectory " + lp + " does not exist. It has now been created." )();
+			mkdir@OSInst( lp )()
+		};
+		
+		install ( CannotCopyInstallers => 
+			sleep@Time( 1000 )();
+			println@Console( main.CannotCopyInstallers.message )(); 
+			throw( FaultInstallation )
+		);
+		copyLaunchers@OSInst( lp )();
+
+		println@Console( "\nJolie launcher executables installed in path " + lp + "\n" )();
+
+		installationFinished@OSInst( jh )();
+
+		if ( nonStop ) {
+			println@Console("\nJolie is installed.")()
+		} else {
+			println@Console("\nJolie is installed. Try running 'jolie' under a new shell [press Enter to exit]")()
 		}
 	} else {
-		println@Console( "\nDirectory " + jh + " does not exist. It has now been created." )();
-		mkdir@OSInst( jh )()
-	} ;
-
-	install ( CannotCopyBins => 
-		sleep@Time( 1000 )();
-		println@Console( main.CannotCopyBins.message )();
-		throw( FaultInstallation )
-	);
-	copyBins@OSInst( jh )();
-		
-	println@Console( "\nJolie libraries installed in path " + jh + "\n" )();
-
-	setLPProc;
-	isDirectory@File( lp )( exists );
-	if ( !exists ) {
-		println@Console( "\nDirectory " + lp + " does not exist. It has now been created." )();
-		mkdir@OSInst( lp )()
-	};
-	
-	install ( CannotCopyInstallers => 
-		sleep@Time( 1000 )();
-		println@Console( main.CannotCopyInstallers.message )(); 
-		throw( FaultInstallation )
-	);
-	copyLaunchers@OSInst( lp )();
-
-	println@Console( "\nJolie launcher executables installed in path " + lp + "\n" )();
-
-	installationFinished@OSInst( jh )();
-
-	println@Console( "\nJolie is installed. Try running 'jolie' under a new shell [press Enter to exit]" )()
+		println@Console(
+			"Jolie installer\n\nUsage:\njava -jar <Jolie installer jar> [options...]\n\n" +
+			"Following options are available:"
+			)();
+		if (args[0] == "nix") {
+			println@Console( 
+				"    -h | --help\t Show this help message\n" +
+				"    -y\t Run the installer in non-interactive mode (Note: This does not set the environmental variable JOLIE_HOME, do this manually)\n" 
+			)()
+		} else {
+			// windows cmd
+			println@Console( 
+				"    /h | /help\t Show this help message\n" +
+				"    /y\t Run the installer in non-interactive mode\n" 
+			)()
+		};
+		println@Console(
+			"See http://http://jolie-lang.org/downloads.html for further details"
+			)()
+	}
 }

--- a/scripts/installer.ol
+++ b/scripts/installer.ol
@@ -176,7 +176,7 @@ main
 		if ( nonStop ) {
 			println@Console("\nJolie is installed.")()
 		} else {
-			println@Console("\nJolie is installed. Try running 'jolie' under a new shell [press Enter to exit]")()
+			println@Console("\nJolie is installed. Try running 'jolie' under a new shell")()
 		}
 	} else {
 		println@Console(


### PR DESCRIPTION
Added a simple command line argument parser in the Java source for the Jolie installer tool. 
This allow the Jolie installer script to handle input given to the jar.

As of now only the non-interaction and help option is available but the number of options can be extended by modifying the Jolie installer script `installer.ol`.
